### PR TITLE
Improve error handling for albums and add support for UtaiteDB and TouhouDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pyright
+pyrightconfig.json
+
+# typestubs
+typings

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Plugins for beets to use VocaDB, UtaiteDB and TouhouDB as autotagger sources.
 ## Installation
 
 ```Shell
-pip install git+https://github.com/amogus07/beets-vocadb
+pip install git+https://github.com/prTopi/beets-vocadb
 ```
 
 or, if you use [pipx](https://pipx.pypa.io):
 
 ```Shell
-pipx inject beets git+https://github.com/amogus07/beets-vocadb
+pipx inject beets git+https://github.com/prTopi/beets-vocadb
 ```
 
 This repository contains 3 plugins: vocadb, utaitedb and touhoudb.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Plugins for beets to use VocaDB, UtaiteDB and TouhouDB as autotagger sources.
 ## Installation
 
 ```Shell
-pip install git+https://github.com/prTopi/beets-vocadb
+pip install git+https://github.com/amogus07/beets-vocadb
 ```
 
 or, if you use [pipx](https://pipx.pypa.io):
 
 ```Shell
-pipx inject beets git+https://github.com/prTopi/beets-vocadb
+pipx inject beets git+https://github.com/amogus07/beets-vocadb
 ```
 
 This repository contains 3 plugins: vocadb, utaitedb and touhoudb.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ vocadb:
 
 utaitedb and touhoudb have the same configuration options.
 
-### Advanced configuration
+## Advanced configuration
 
 If you want to use another site based on VocaDB, create another .py file in the beetsplug directory.
 Look at utaitedb.py and touhoudb.py for reference

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # beets-vocadb
 
-Plugin for beets to use VocaDB, UtaiteDB and TouhouDB as an autotagger source.
+Plugins for beets to use VocaDB, UtaiteDB and TouhouDB as autotagger sources.
 
 ## Installation
 
@@ -14,7 +14,7 @@ or, if you use [pipx](https://pipx.pypa.io):
 pipx inject beets git+https://github.com/prTopi/beets-vocadb
 ```
 
-This Plugin has 3 components: vocadb, utaitedb and touhoudb.
+This repository contains 3 plugins: vocadb, utaitedb and touhoudb.
 To enable them, add them to the plugin section of your beets config file:
 
 ```yaml
@@ -24,9 +24,15 @@ plugins:
   - touhoudb
 ```
 
+## Subcommands
+
+Each plugin adds a subcommand to beets that works similarly to the mbsync command.
+vocadb adds `vdbsync`, utaitedb adds `udbsync` and touhoudb adds `tdbsync`.
+For usage information run `beet [subcommand] -h`.
+
 ## Configuration
 
-The plugin uses beets default language list to determine which language to use
+The plugins use beets default language list to determine which language to use
 for tags.
 
 ```yaml

--- a/beetsplug/touhoudb.py
+++ b/beetsplug/touhoudb.py
@@ -1,12 +1,13 @@
 from beetsplug.vocadb import VocaDBPlugin, VocaDBInstance
 
 
-class TouhouDBPlugin(VocaDBPlugin):
-    def __init__(self) -> None:
-        super().__init__()
-        self.instance = VocaDBInstance(
-            name="TouhouDB",
-            base_url="https://touhoudb.com/",
-            api_url="https://touhoudb.com/api/",
-            subcommand="tdbsync",
-        )
+class TouhouDBPlugin(
+    VocaDBPlugin,
+    instance = VocaDBInstance(
+        name="TouhouDB",
+        base_url="https://touhoudb.com/",
+        api_url="https://touhoudb.com/api/",
+        subcommand="tdbsync",
+    )
+):
+    ...

--- a/beetsplug/touhoudb.py
+++ b/beetsplug/touhoudb.py
@@ -3,11 +3,10 @@ from beetsplug.vocadb import VocaDBPlugin, VocaDBInstance
 
 class TouhouDBPlugin(
     VocaDBPlugin,
-    instance = VocaDBInstance(
+    instance=VocaDBInstance(
         name="TouhouDB",
         base_url="https://touhoudb.com/",
         api_url="https://touhoudb.com/api/",
         subcommand="tdbsync",
-    )
-):
-    ...
+    ),
+): ...

--- a/beetsplug/touhoudb.py
+++ b/beetsplug/touhoudb.py
@@ -1,9 +1,11 @@
-from beetsplug.vocadb import VocaDBPlugin
+from beetsplug.vocadb import VocaDBPlugin, VocaDBInstance
 
 class TouhouDBPlugin(VocaDBPlugin):
     def __init__(self):
         super().__init__()
         self.data_source = "TouhouDB"
-        self.base_url = "https://touhoudb.com/"
-        self.api_url = "https://touhoudb.com/api/"
-        self.subcommand = "tdbsync"
+        self.instance = VocaDBInstance(
+            base_url = "https://touhoudb.com/",
+            api_url = "https://touhoudb.com/api/",
+            subcommand = "tdbsync"
+        )

--- a/beetsplug/touhoudb.py
+++ b/beetsplug/touhoudb.py
@@ -3,7 +3,7 @@ from beetsplug.vocadb import VocaDBPlugin
 class TouhouDBPlugin(VocaDBPlugin):
     def __init__(self):
         super().__init__()
-        self.db_name = "TouhouDB"
+        self.data_source = "TouhouDB"
         self.base_url = "https://touhoudb.com/"
         self.api_url = "https://touhoudb.com/api/"
         self.subcommand = "tdbsync"

--- a/beetsplug/utaitedb.py
+++ b/beetsplug/utaitedb.py
@@ -3,7 +3,7 @@ from beetsplug.vocadb import VocaDBPlugin
 class UtaiteDBPlugin(VocaDBPlugin):
     def __init__(self):
         super().__init__()
-        self.db_name = "UtaiteDB"
+        self.data_source = "UtaiteDB"
         self.base_url = "https://utaiteadb.net/"
         self.api_url = "https://utaitedb.net/api/"
         self.subcommand = "udbsync"

--- a/beetsplug/utaitedb.py
+++ b/beetsplug/utaitedb.py
@@ -2,11 +2,11 @@ from beetsplug.vocadb import VocaDBPlugin, VocaDBInstance
 
 
 class UtaiteDBPlugin(
-    VocaDBPlugin, instance = VocaDBInstance(
+    VocaDBPlugin,
+    instance=VocaDBInstance(
         name="UtaiteDB",
         base_url="https://utaiteadb.net/",
         api_url="https://utaitedb.net/api/",
         subcommand="udbsync",
-    )
-):
-    ...
+    ),
+): ...

--- a/beetsplug/utaitedb.py
+++ b/beetsplug/utaitedb.py
@@ -1,12 +1,12 @@
 from beetsplug.vocadb import VocaDBPlugin, VocaDBInstance
 
 
-class UtaiteDBPlugin(VocaDBPlugin):
-    def __init__(self) -> None:
-        super().__init__()
-        self.instance = VocaDBInstance(
-            name="UtaiteDB",
-            base_url="https://utaiteadb.net/",
-            api_url="https://utaitedb.net/api/",
-            subcommand="udbsync",
-        )
+class UtaiteDBPlugin(
+    VocaDBPlugin, instance = VocaDBInstance(
+        name="UtaiteDB",
+        base_url="https://utaiteadb.net/",
+        api_url="https://utaitedb.net/api/",
+        subcommand="udbsync",
+    )
+):
+    ...

--- a/beetsplug/utaitedb.py
+++ b/beetsplug/utaitedb.py
@@ -1,9 +1,11 @@
-from beetsplug.vocadb import VocaDBPlugin
+from beetsplug.vocadb import VocaDBPlugin, VocaDBInstance
 
 class UtaiteDBPlugin(VocaDBPlugin):
     def __init__(self):
         super().__init__()
         self.data_source = "UtaiteDB"
-        self.base_url = "https://utaiteadb.net/"
-        self.api_url = "https://utaitedb.net/api/"
-        self.subcommand = "udbsync"
+        self.instance = VocaDBInstance(
+            base_url = "https://utaiteadb.net/",
+            api_url = "https://utaitedb.net/api/",
+            subcommand = "udbsync"
+        )

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -285,10 +285,10 @@ class VocaDBPlugin(BeetsPlugin):
                     return tuple([album for album in map(self.album_for_id, ids) if album])
                 else:
                     self._log.debug("API Error: Returned empty page (query: {0})", url)
-                    return tuple([])
+                    return tuple()
         except HTTPError as e:
             self._log.debug("API Error: {0} (query: {1})", e, url)
-            return tuple([])
+            return tuple()
 
     def item_candidates(self, item: Item, artist: str, title: str) -> tuple[()]:
         self._log.debug("Searching for track {0}", item)
@@ -311,10 +311,10 @@ class VocaDBPlugin(BeetsPlugin):
                     ])
                 else:
                     self._log.debug("API Error: Returned empty page (query: {0})", url)
-                    return tuple([])
+                    return tuple()
         except HTTPError as e:
             self._log.debug("API Error: {0} (query: {1})", e, url)
-            return tuple([])
+            return tuple()
 
     def album_for_id(self, album_id: str) -> Optional[AlbumInfo]:
         self._log.debug("Searching for album {0}", album_id)

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -406,8 +406,10 @@ class VocaDBPlugin(BeetsPlugin):
                 [id for id in category.values() if id not in artists_ids]
             )
         artist_id: Optional[str] = None
-        if artists_ids:
+        try:
             artist_id = artists_ids[0]
+        except IndexError:
+            pass
         tracks, script, language = self.get_album_track_infos(
             release["tracks"], release["discs"], ignored_discs, search_lang
         )
@@ -436,8 +438,10 @@ class VocaDBPlugin(BeetsPlugin):
         catalognum: Optional[str] = release.get("catalogNumber", None)
         genre: str = self.get_genres(release)
         media: Optional[str] = None
-        if release["discs"]:
+        try:
             media = release["discs"][0]["name"]
+        except IndexError:
+            pass
         data_url: str = urljoin(self.instance.base_url, f"Al/{album_id}")
         return AlbumInfo(
             album=album,
@@ -488,8 +492,10 @@ class VocaDBPlugin(BeetsPlugin):
                 [id for id in category.values() if id not in artists_ids]
             )
         artist_id: Optional[str] = None
-        if artists_ids:
+        try:
             artist_id = artists_ids[0]
+        except IndexError:
+            pass
         arranger: str = ", ".join(artist_categories["arrangers"])
         composer: str = ", ".join(artist_categories["composers"])
         lyricist: str = ", ".join(artist_categories["lyricists"])

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -81,14 +81,14 @@ class VocaDBPlugin(BeetsPlugin):
         for item in lib.items(query + ["singleton:true"]):
             item_formatted = format(item)
             if not item.mb_trackid:
-                self._log.info(
+                self._log.debug(
                     "Skipping singleton with no mb_trackid: {0}", item_formatted
                 )
                 continue
             if not (
                 item.get("data_source") == VOCADB_NAME and item.mb_trackid.isnumeric()
             ):
-                self._log.info(
+                self._log.debug(
                     "Skipping non-{0} singleton: {1}", VOCADB_NAME, item_formatted
                 )
                 continue
@@ -106,7 +106,9 @@ class VocaDBPlugin(BeetsPlugin):
                 apply_item_changes(lib, item, move, pretend, write)
 
     def albums(self, lib, query, move, pretend, write):
-        """Retrieve and apply info from the autotagger for albums matched by query and their items."""
+        """Retrieve and apply info from the autotagger for albums matched by
+        query and their items.
+        """
         for album in lib.albums(query):
             album_formatted = format(album)
             if not album.mb_albumid:

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -14,7 +14,7 @@ from beets.plugins import BeetsPlugin, apply_item_changes, get_distance
 class VocaDBPlugin(BeetsPlugin):
     def __init__(self):
         super().__init__()
-        self.db_name = "VocaDB"
+        self.data_source = "VocaDB"
         self.base_url = "https://vocadb.net/"
         self.api_url = "https://vocadb.net/api/"
         self.subcommand = "vdbsync"
@@ -29,7 +29,7 @@ class VocaDBPlugin(BeetsPlugin):
         )
 
     def commands(self):
-        cmd = ui.Subcommand(self.subcommand, help=f"update metadata from {self.db_name}")
+        cmd = ui.Subcommand(self.subcommand, help=f"update metadata from {self.data_source}")
         cmd.parser.add_option(
             "-p",
             "--pretend",
@@ -84,10 +84,10 @@ class VocaDBPlugin(BeetsPlugin):
                 )
                 continue
             if not (
-                item.get("data_source") == self.db_name and item.mb_trackid.isnumeric()
+                item.get("data_source") == self.data_source and item.mb_trackid.isnumeric()
             ):
                 self._log.debug(
-                    "Skipping non-{0} singleton: {1}", self.db_name, item_formatted
+                    "Skipping non-{0} singleton: {1}", self.data_source, item_formatted
                 )
                 continue
             track_info = self.track_for_id(item.mb_trackid)
@@ -116,10 +116,10 @@ class VocaDBPlugin(BeetsPlugin):
                 continue
             items = list(album.items())
             if not (
-                album.get("data_source") == self.db_name and album.mb_albumid.isnumeric()
+                album.get("data_source") == self.data_source and album.mb_albumid.isnumeric()
             ):
                 self._log.debug(
-                    "Skipping non-{0} album: {1}", self.db_name, album_formatted
+                    "Skipping non-{0} album: {1}", self.data_source, album_formatted
                 )
                 continue
             album_info = self.album_for_id(album.mb_albumid)
@@ -183,12 +183,12 @@ class VocaDBPlugin(BeetsPlugin):
 
     def track_distance(self, item, info):
         """Returns the track distance."""
-        return get_distance(data_source=self.db_name, info=info, config=self.config)
+        return get_distance(data_source=self.data_source, info=info, config=self.config)
 
     def album_distance(self, items, album_info, mapping):
         """Returns the album distance."""
         return get_distance(
-            data_source=self.db_name, info=album_info, config=self.config
+            data_source=self.data_source, info=album_info, config=self.config
         )
 
     def candidates(self, items, artist, album, va_likely, extra_tags=None):
@@ -383,7 +383,7 @@ class VocaDBPlugin(BeetsPlugin):
             language=language,
             genre=genre,
             media=media,
-            data_source=self.db_name,
+            data_source=self.data_source,
             data_url=data_url,
         )
 
@@ -446,7 +446,7 @@ class VocaDBPlugin(BeetsPlugin):
             medium=medium,
             medium_index=medium_index,
             medium_total=medium_total,
-            data_source=self.db_name,
+            data_source=self.data_source,
             data_url=data_url,
             lyricist=lyricist,
             composer=composer,

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -287,10 +287,10 @@ class VocaDBPlugin(BeetsPlugin):
                     )
                 else:
                     self._log.debug("API Error: Returned empty page (query: {0})", url)
-                    return tuple()
+                    return tuple([])
         except HTTPError as e:
             self._log.debug("API Error: {0} (query: {1})", e, url)
-            return tuple()
+            return tuple([])
 
     def item_candidates(self, item: Item, artist: str, title: str) -> tuple[()]:
         self._log.debug("Searching for track {0}", item)
@@ -315,10 +315,10 @@ class VocaDBPlugin(BeetsPlugin):
                     )
                 else:
                     self._log.debug("API Error: Returned empty page (query: {0})", url)
-                    return tuple()
+                    return tuple([])
         except HTTPError as e:
             self._log.debug("API Error: {0} (query: {1})", e, url)
-            return tuple()
+            return tuple([])
 
     def album_for_id(self, album_id: str) -> Optional[AlbumInfo]:
         self._log.debug("Searching for album {0}", album_id)

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -326,7 +326,7 @@ class VocaDBPlugin(BeetsPlugin):
             + f"&songFields={self.song_fields}"
             + f"&lang={language}",
         )
-        request = Request(url, headers=self.headers)
+        request: Request = Request(url, headers=self.headers)
         try:
             with urlopen(request) as result:
                 if result:

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -282,7 +282,9 @@ class VocaDBPlugin(BeetsPlugin):
                     # songFields parameter doesn't exist for album search
                     # so we'll get albums by their id
                     ids: list[str] = [str(x["id"]) for x in result["items"]]
-                    return tuple([album for album in map(self.album_for_id, ids) if album])
+                    return tuple(
+                        [album for album in map(self.album_for_id, ids) if album]
+                    )
                 else:
                     self._log.debug("API Error: Returned empty page (query: {0})", url)
                     return tuple()
@@ -304,11 +306,13 @@ class VocaDBPlugin(BeetsPlugin):
             with urlopen(request) as result:
                 if result:
                     result = load(result)
-                    return tuple([
-                        track
-                        for track in map(self.track_info, result["items"])
-                        if track
-                    ])
+                    return tuple(
+                        [
+                            track
+                            for track in map(self.track_info, result["items"])
+                            if track
+                        ]
+                    )
                 else:
                     self._log.debug("API Error: Returned empty page (query: {0})", url)
                     return tuple()
@@ -344,9 +348,7 @@ class VocaDBPlugin(BeetsPlugin):
         language: str = self.language
         url: str = urljoin(
             self.instance.api_url,
-            f"songs/{track_id}"
-            + f"?fields={self.song_fields}"
-            + f"&lang={language}",
+            f"songs/{track_id}" + f"?fields={self.song_fields}" + f"&lang={language}",
         )
         request: Request = Request(url, headers=self.headers)
         try:
@@ -392,7 +394,10 @@ class VocaDBPlugin(BeetsPlugin):
         album: str = release["name"]
         album_id: str = str(release["id"])
         artist_categories, artist = self.get_artists(
-            release["artists"], self.va_string, include_featured_artists=self.include_featured_album_artists, comp=va
+            release["artists"],
+            self.va_string,
+            include_featured_artists=self.include_featured_album_artists,
+            comp=va,
         )
         if artist == self.va_string:
             va = True
@@ -481,7 +486,9 @@ class VocaDBPlugin(BeetsPlugin):
     ) -> TrackInfo:
         title: str = recording["name"]
         track_id: str = str(recording["id"])
-        artist_categories, artist = self.get_artists(recording["artists"], self.va_string, include_featured_artists=True)
+        artist_categories, artist = self.get_artists(
+            recording["artists"], self.va_string, include_featured_artists=True
+        )
         artists: list[str] = []
         artists_ids: list[str] = []
         for category in artist_categories.values():
@@ -586,7 +593,7 @@ class VocaDBPlugin(BeetsPlugin):
         artists: list[dict[str, Any]],
         va_string: str,
         include_featured_artists: bool,
-        comp: bool = False
+        comp: bool = False,
     ) -> tuple[dict[str, dict[str, Any]], str]:
         out: dict[str, dict[str, Any]] = {
             "producers": {},
@@ -652,9 +659,7 @@ class VocaDBPlugin(BeetsPlugin):
 
         if include_featured_artists and out["vocalists"] and main_artists:
             featured_artists: list[str] = [
-                name
-                for name, id in out["vocalists"].items()
-                if id not in is_support
+                name for name, id in out["vocalists"].items() if id not in is_support
             ]
             if featured_artists and not len(main_artists) + len(featured_artists) > 5:
                 artist_string += " feat. " + ", ".join(featured_artists)
@@ -684,9 +689,10 @@ class VocaDBPlugin(BeetsPlugin):
 
     @classmethod
     def get_lyrics(
-        cls, lyrics: list[dict[str, Any]],
+        cls,
+        lyrics: list[dict[str, Any]],
         language: Optional[str],
-        translated_lyrics: bool = False
+        translated_lyrics: bool = False,
     ) -> tuple[Optional[str], Optional[str], Optional[str]]:
         out_script: Optional[str] = None
         out_language: Optional[str] = None

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -77,7 +77,7 @@ class VocaDBPlugin(BeetsPlugin):
     def va_string(self) -> str:
         return str(self.config["va_string"].get())
 
-    def commands(self) -> list[Subcommand]:
+    def commands(self) -> tuple[()]:
         cmd: Subcommand = Subcommand(
             self.instance.subcommand,
             help=f"update metadata from {self.data_source}",
@@ -112,7 +112,7 @@ class VocaDBPlugin(BeetsPlugin):
         )
         cmd.parser.add_format_option()
         cmd.func = self.func
-        return [cmd]
+        return tuple([cmd])
 
     def func(self, lib: Library, opts, args) -> None:
         """Command handler for the *dbsync function."""
@@ -268,7 +268,7 @@ class VocaDBPlugin(BeetsPlugin):
         album: str,
         va_likely: bool,
         extra_tags: Optional[dict] = None,
-    ) -> list[AlbumInfo]:
+    ) -> tuple[()]:
         self._log.debug("Searching for album {0}", album)
         url: str = urljoin(
             self.instance.api_url,
@@ -282,15 +282,15 @@ class VocaDBPlugin(BeetsPlugin):
                     # songFields parameter doesn't exist for album search
                     # so we'll get albums by their id
                     ids: list[str] = [str(x["id"]) for x in result["items"]]
-                    return [album for album in map(self.album_for_id, ids) if album]
+                    return tuple([album for album in map(self.album_for_id, ids) if album])
                 else:
                     self._log.debug("API Error: Returned empty page (query: {0})", url)
-                    return []
+                    return tuple([])
         except HTTPError as e:
             self._log.debug("API Error: {0} (query: {1})", e, url)
-            return []
+            return tuple([])
 
-    def item_candidates(self, item: Item, artist: str, title: str) -> list[TrackInfo]:
+    def item_candidates(self, item: Item, artist: str, title: str) -> tuple[()]:
         self._log.debug("Searching for track {0}", item)
         url: str = urljoin(
             self.instance.api_url,
@@ -304,17 +304,17 @@ class VocaDBPlugin(BeetsPlugin):
             with urlopen(request) as result:
                 if result:
                     result = load(result)
-                    return [
+                    return tuple([
                         track
                         for track in map(self.track_info, result["items"])
                         if track
-                    ]
+                    ])
                 else:
                     self._log.debug("API Error: Returned empty page (query: {0})", url)
-                    return []
+                    return tuple([])
         except HTTPError as e:
             self._log.debug("API Error: {0} (query: {1})", e, url)
-            return []
+            return tuple([])
 
     def album_for_id(self, album_id: str) -> Optional[AlbumInfo]:
         self._log.debug("Searching for album {0}", album_id)

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -634,21 +634,31 @@ class VocaDBPlugin(BeetsPlugin):
             out["composers"] = out["producers"]
         if not out["lyricists"]:
             out["lyricists"] = out["producers"]
-        if comp or len(out["producers"]) > 5:
-            return out, va_string
-        artist_string: str = ", ".join(
-            main_artist
-            for main_artist, id in chain(out["producers"].items(), out["circles"].items())
-            if id not in is_support
-        )
-        if include_featured_artists and out["vocalists"]:
+
+        artist_string: Optional[str] = None
+        main_artists: Optional[list[str]] = None
+
+        if not comp:
+            main_artists = [
+                name
+                for name, id in chain(out["producers"].items(), out["circles"].items())
+                if id not in is_support
+            ]
+            if not len(main_artists) > 5:
+                artist_string = ", ".join(main_artists)
+
+        if not artist_string:
+            artist_string = va_string
+
+        if include_featured_artists and out["vocalists"] and main_artists:
             featured_artists: list[str] = [
                 name
                 for name, id in out["vocalists"].items()
-                if name not in out["producers"] and id not in is_support
+                if id not in is_support
             ]
-            if featured_artists:
+            if featured_artists and not len(main_artists) + len(featured_artists) > 5:
                 artist_string += " feat. " + ", ".join(featured_artists)
+
         return out, artist_string
 
     @staticmethod

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -630,7 +630,7 @@ class VocaDBPlugin(BeetsPlugin):
             out["lyricists"] = out["producers"]
         if comp or len(out["producers"]) > 5:
             return out, va_string
-        artistString: str = ", ".join(
+        artist_string: str = ", ".join(
             main_artist
             for main_artist, id in chain(out["producers"].items(), out["circles"].items())
             if id not in is_support
@@ -642,8 +642,8 @@ class VocaDBPlugin(BeetsPlugin):
                 if name not in out["producers"] and id not in is_support
             ]
             if featured_artists:
-                artistString += " feat. " + ", ".join(featured_artists)
-        return out, artistString
+                artist_string += " feat. " + ", ".join(featured_artists)
+        return out, artist_string
 
     @staticmethod
     def get_genres(info: dict[str, Any]) -> str:

--- a/beetsplug/vocadb.py
+++ b/beetsplug/vocadb.py
@@ -23,14 +23,23 @@ class VocaDBInstance(NamedTuple):
 
 
 class VocaDBPlugin(BeetsPlugin):
+
+    user_agent: str = f"beets/{beets.__version__} +https://beets.io/"
+    headers: dict[str, str] = {"accept": "application/json", "User-Agent": user_agent}
+    languages = config["import"]["languages"].as_str_seq()
+    song_fields: str = "Artists,Tags,Bpm,Lyrics"
+
+    instance: VocaDBInstance
+
     def __init__(self) -> None:
         super().__init__()
-        self.instance: VocaDBInstance = VocaDBInstance(
-            name="VocaDB",
-            base_url="https://vocadb.net/",
-            api_url="https://vocadb.net/api/",
-            subcommand="vdbsync",
-        )
+        if not hasattr(self, "instance"):
+            self.instance = VocaDBInstance(
+                name="VocaDB",
+                base_url="https://vocadb.net/",
+                api_url="https://vocadb.net/api/",
+                subcommand="vdbsync",
+            )
         self.config.add(
             {
                 "source_weight": 0.5,
@@ -41,10 +50,8 @@ class VocaDBPlugin(BeetsPlugin):
             }
         )
 
-    user_agent: str = f"beets/{beets.__version__} +https://beets.io/"
-    headers: dict[str, str] = {"accept": "application/json", "User-Agent": user_agent}
-    languages = config["import"]["languages"].as_str_seq()
-    song_fields: str = "Artists,Tags,Bpm,Lyrics"
+    def __init_subclass__(cls, instance: VocaDBInstance) -> None:
+        cls.instance = instance
 
     @property
     def language(self) -> str:

--- a/tests/test_touhoudb.py
+++ b/tests/test_touhoudb.py
@@ -1,0 +1,6 @@
+from beetsplug.touhoudb import TouhouDBPlugin
+from tests.test_vocadb import TestVocaDBPlugin
+
+class TestTouhouDBPlugin(TestVocaDBPlugin):
+    def setUp(self):
+        self.plugin = TouhouDBPlugin()

--- a/tests/test_touhoudb.py
+++ b/tests/test_touhoudb.py
@@ -1,6 +1,7 @@
 from beetsplug.touhoudb import TouhouDBPlugin
 from tests.test_vocadb import TestVocaDBPlugin
 
+
 class TestTouhouDBPlugin(TestVocaDBPlugin):
-    def setUp(self):
+    def setUp(self) -> None:
         self.plugin = TouhouDBPlugin()

--- a/tests/test_utaitedb.py
+++ b/tests/test_utaitedb.py
@@ -1,0 +1,6 @@
+from beetsplug.utaitedb import UtaiteDBPlugin
+from tests.test_vocadb import TestVocaDBPlugin
+
+class TestUtaiteDBPlugin(TestVocaDBPlugin):
+    def setUp(self):
+        self.plugin = UtaiteDBPlugin()

--- a/tests/test_utaitedb.py
+++ b/tests/test_utaitedb.py
@@ -1,6 +1,7 @@
 from beetsplug.utaitedb import UtaiteDBPlugin
 from tests.test_vocadb import TestVocaDBPlugin
 
+
 class TestUtaiteDBPlugin(TestVocaDBPlugin):
-    def setUp(self):
+    def setUp(self) -> None:
         self.plugin = UtaiteDBPlugin()

--- a/tests/test_vocadb.py
+++ b/tests/test_vocadb.py
@@ -66,10 +66,18 @@ class TestVocaDBPlugin(TestCase):
         self.assertEqual(self.plugin.get_genres(info), "Genre2")
 
     def test_get_lang(self) -> None:
-        self.assertEqual(self.plugin.get_lang(["en", "jp"], prefer_romaji=False), "English")
-        self.assertEqual(self.plugin.get_lang(["jp", "en"], prefer_romaji=False), "Japanese")
-        self.assertEqual(self.plugin.get_lang(["jp", "en"], prefer_romaji=True), "Romaji")
-        self.assertEqual(self.plugin.get_lang(["en", "jp"], prefer_romaji=True), "English")
+        self.assertEqual(
+            self.plugin.get_lang(["en", "jp"], prefer_romaji=False), "English"
+        )
+        self.assertEqual(
+            self.plugin.get_lang(["jp", "en"], prefer_romaji=False), "Japanese"
+        )
+        self.assertEqual(
+            self.plugin.get_lang(["jp", "en"], prefer_romaji=True), "Romaji"
+        )
+        self.assertEqual(
+            self.plugin.get_lang(["en", "jp"], prefer_romaji=True), "English"
+        )
         self.assertEqual(self.plugin.get_lang([], prefer_romaji=True), "English")
 
     def test_get_lyrics(self) -> None:

--- a/tests/test_vocadb.py
+++ b/tests/test_vocadb.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import TestCase
 
 from beetsplug.vocadb import VocaDBPlugin
@@ -8,7 +9,7 @@ class TestVocaDBPlugin(TestCase):
         self.plugin = VocaDBPlugin()
 
     def test_get_genres(self):
-        info = {}
+        info: dict[str, list[dict[str, Any]]] = {}
         self.assertEqual(self.plugin.get_genres(info), "")
         info = {
             "tags": [

--- a/tests/test_vocadb.py
+++ b/tests/test_vocadb.py
@@ -5,10 +5,13 @@ from beetsplug.vocadb import VocaDBPlugin
 
 
 class TestVocaDBPlugin(TestCase):
-    def setUp(self):
+
+    plugin: VocaDBPlugin
+
+    def setUp(self) -> None:
         self.plugin = VocaDBPlugin()
 
-    def test_get_genres(self):
+    def test_get_genres(self) -> None:
         info: dict[str, list[dict[str, Any]]] = {}
         self.assertEqual(self.plugin.get_genres(info), "")
         info = {
@@ -62,15 +65,15 @@ class TestVocaDBPlugin(TestCase):
         }
         self.assertEqual(self.plugin.get_genres(info), "Genre2")
 
-    def test_get_lang(self):
+    def test_get_lang(self) -> None:
         self.assertEqual(self.plugin.get_lang(["en", "jp"], prefer_romaji=False), "English")
         self.assertEqual(self.plugin.get_lang(["jp", "en"], prefer_romaji=False), "Japanese")
         self.assertEqual(self.plugin.get_lang(["jp", "en"], prefer_romaji=True), "Romaji")
         self.assertEqual(self.plugin.get_lang(["en", "jp"], prefer_romaji=True), "English")
         self.assertEqual(self.plugin.get_lang([], prefer_romaji=True), "English")
 
-    def test_get_lyrics(self):
-        lyrics = [
+    def test_get_lyrics(self) -> None:
+        lyrics: list[dict[str, Any]] = [
             {
                 "cultureCodes": ["ja"],
                 "translationType": "Original",
@@ -128,8 +131,8 @@ class TestVocaDBPlugin(TestCase):
             self.plugin.get_lyrics(lyrics, "English"), ("Jpan", "jpn", "lyrics1")
         )
 
-    def test_get_fallback_lyrics(self):
-        lyrics = [
+    def test_get_fallback_lyrics(self) -> None:
+        lyrics: list[dict[str, Any]] = [
             {
                 "cultureCodes": ["ja"],
                 "translationType": "Original",


### PR DESCRIPTION
I recently ran into a problem when running `beet vdbsync`. It would throw the following error:
```
Traceback (most recent call last):
  File "/home/konstantink/.local/bin/beet", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/ui/__init__.py", line 1865, in main
    _raw_main(args)
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/ui/__init__.py", line 1852, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beetsplug/vocadb.py", line 75, in func
    self.albums(lib, query, move, pretend, write)
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beetsplug/vocadb.py", line 140, in albums
    item: trackid_to_trackinfo[track_id]
          ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: '3312'
```
It appears that this error occurs when the id of a track of a VocaDB album is changed on the server.
 I had ChatGPT fix it, and it seems to be working.
I also changed log.info to log.debug in some places to make the output of vdbsync more comprehensible.